### PR TITLE
Add gamification profile page with Next.js

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "gamification-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "13.4.12",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@mui/material": "5.14.9",
+    "@mui/icons-material": "5.14.9",
+    "@emotion/react": "^11.11.1",
+    "@emotion/styled": "^11.11.0",
+    "@tanstack/react-query": "4.29.10",
+    "react-countup": "6.3.0"
+  }
+}

--- a/frontend/pages/_app.js
+++ b/frontend/pages/_app.js
@@ -1,0 +1,18 @@
+import { useState } from 'react';
+import { CssBaseline } from '@mui/material';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+export default function MyApp({ Component, pageProps }) {
+  const [queryClient] = useState(() => new QueryClient());
+  const theme = createTheme();
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <Component {...pageProps} />
+      </ThemeProvider>
+    </QueryClientProvider>
+  );
+}

--- a/frontend/pages/api/user/[id]/gamification.js
+++ b/frontend/pages/api/user/[id]/gamification.js
@@ -1,0 +1,20 @@
+export default function handler(req, res) {
+  const {
+    query: { id },
+  } = req;
+
+  res.status(200).json({
+    userId: id,
+    name: 'Jane Doe',
+    avatarUrl: 'https://via.placeholder.com/150',
+    totalPoints: 1234,
+    streakDays: 5,
+    streakMultiplier: 1.2,
+    totalCommandsExecuted: 42,
+    badges: [
+      { id: '1', label: 'Beginner', iconUrl: 'https://via.placeholder.com/32' },
+      { id: '2', label: 'Power User', iconUrl: 'https://via.placeholder.com/32' },
+      { id: '3', label: 'Veteran', iconUrl: 'https://via.placeholder.com/32' },
+    ],
+  });
+}

--- a/frontend/pages/user/[id]/gamification.js
+++ b/frontend/pages/user/[id]/gamification.js
@@ -1,0 +1,158 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import {
+  Avatar,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CircularProgress,
+  Container,
+  Grid,
+  Typography,
+  Alert,
+  Snackbar,
+} from '@mui/material';
+import CountUp from 'react-countup';
+import { useQuery } from '@tanstack/react-query';
+
+const fetchGamification = async (id) => {
+  const res = await fetch(`/api/user/${id}/gamification`);
+  if (!res.ok) throw new Error('Failed to fetch');
+  return res.json();
+};
+
+export default function GamificationProfile() {
+  const router = useRouter();
+  const { id } = router.query;
+
+  const { data, isLoading, error, refetch } = useQuery(
+    ['gamification', id],
+    () => fetchGamification(id),
+    { enabled: !!id }
+  );
+
+  const [points, setPoints] = useState(0);
+  const [toastOpen, setToastOpen] = useState(false);
+
+  useEffect(() => {
+    if (data) {
+      setPoints(data.totalPoints);
+    }
+  }, [data]);
+
+  const handleEarnPoint = () => {
+    setPoints((p) => p + 1);
+    setToastOpen(true);
+  };
+
+  const handleClose = (_, reason) => {
+    if (reason === 'clickaway') return;
+    setToastOpen(false);
+  };
+
+  if (isLoading) {
+    return (
+      <Box display="flex" justifyContent="center" mt={4}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box display="flex" flexDirection="column" alignItems="center" mt={4}>
+        <Alert severity="error" sx={{ mb: 2 }}>
+          Failed to load user profile.
+        </Alert>
+        <Button variant="contained" onClick={() => refetch()}>
+          Retry
+        </Button>
+      </Box>
+    );
+  }
+
+  if (!data) return null;
+
+  return (
+    <Container maxWidth={false} sx={{ mt: 4 }}>
+      <Grid container spacing={2}>
+        <Grid item xs={12} md={4}>
+          <Box display="flex" flexDirection="column" justifyContent="center" alignItems="center" height="100%">
+            <Avatar src={data.avatarUrl} alt={data.name} sx={{ width: 120, height: 120, mb: 2 }} />
+            <Typography variant="h6">{data.name}</Typography>
+            <Box mt={2}>
+              <Button variant="contained" onClick={handleEarnPoint}>Earn Point</Button>
+            </Box>
+          </Box>
+        </Grid>
+        <Grid item xs={12} md={8}>
+          <Grid container spacing={2} sx={{ mb: 2 }}>
+            <Grid item xs={12} sm={6} md={3}>
+              <Card sx={{ p: 1, transition: 'box-shadow 0.3s', '&:hover': { boxShadow: 6 } }} elevation={3}>
+                <CardContent>
+                  <Typography variant="body2">Total Points</Typography>
+                  <Typography variant="h5">
+                    <CountUp end={points} duration={1} />
+                  </Typography>
+                </CardContent>
+              </Card>
+            </Grid>
+            <Grid item xs={12} sm={6} md={3}>
+              <Card sx={{ p: 1, transition: 'box-shadow 0.3s', '&:hover': { boxShadow: 6 } }} elevation={3}>
+                <CardContent>
+                  <Typography variant="body2">Streak Days</Typography>
+                  <Typography variant="h5">
+                    <CountUp end={data.streakDays} duration={1} />
+                  </Typography>
+                </CardContent>
+              </Card>
+            </Grid>
+            <Grid item xs={12} sm={6} md={3}>
+              <Card sx={{ p: 1, transition: 'box-shadow 0.3s', '&:hover': { boxShadow: 6 } }} elevation={3}>
+                <CardContent>
+                  <Typography variant="body2">Streak Multiplier</Typography>
+                  <Typography variant="h5">
+                    <CountUp end={data.streakMultiplier} duration={1} />
+                  </Typography>
+                </CardContent>
+              </Card>
+            </Grid>
+            <Grid item xs={12} sm={6} md={3}>
+              <Card sx={{ p: 1, transition: 'box-shadow 0.3s', '&:hover': { boxShadow: 6 } }} elevation={3}>
+                <CardContent>
+                  <Typography variant="body2">Total Commands Executed</Typography>
+                  <Typography variant="h5">
+                    <CountUp end={data.totalCommandsExecuted} duration={1} />
+                  </Typography>
+                </CardContent>
+              </Card>
+            </Grid>
+          </Grid>
+          <Grid container spacing={2}>
+            {data.badges.map((badge) => (
+              <Grid item xs={6} sm={4} md={3} key={badge.id}>
+                <Card sx={{ p: 2, textAlign: 'center', transition: 'box-shadow 0.3s', '&:hover': { boxShadow: 6 } }} elevation={1}>
+                  <Box display="flex" flexDirection="column" alignItems="center">
+                    <Avatar src={badge.iconUrl} alt={badge.label} sx={{ mb: 1 }} />
+                    <Typography variant="body2">{badge.label}</Typography>
+                  </Box>
+                </Card>
+              </Grid>
+            ))}
+          </Grid>
+        </Grid>
+      </Grid>
+      <Snackbar
+        open={toastOpen}
+        autoHideDuration={3000}
+        onClose={handleClose}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert onClose={handleClose} severity="success" sx={{ width: '100%' }}>
+          +1 point!
+        </Alert>
+      </Snackbar>
+    </Container>
+  );
+}


### PR DESCRIPTION
## Summary
- create a minimal Next.js frontend
- add `_app` with MUI and React Query providers
- implement `User Gamification Profile` page
- stub API route returning example data
- add package.json with required dependencies

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6866c176634883319e7975013ef30462